### PR TITLE
Fix bit rate change

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -189,6 +189,11 @@ $(function() {
         connection.autoConnect(true);
     });
 
+    $('#bitrate').change(function(e) {
+        e.preventDefault();
+        connection.set('bitrate', parseInt($(this).val()));
+    });
+
     $('#stop-connection').click(function(e) {
         e.preventDefault();
         connection.autoConnect(false);


### PR DESCRIPTION
Bit rate selector was ignored by scripts.

On [Chrome Web Store](https://chrome.google.com/webstore/detail/serial-projector/kbkjgbkmphnikcpkcodjbifkblmgidia/support?hl=uk) page you can find complaints:

[George Bobrov](https://plus.google.com/110452802688340996863)
> Скорость везде 9600.
> Как предварительно отбайндить?:)

[Дмитрий Шестаков](https://plus.google.com/109083304348229294085)
> Не работают скорости выше 9600.