### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,4 +1,6 @@
 name: Deploy
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/amperka/serial-projector/security/code-scanning/1](https://github.com/amperka/serial-projector/security/code-scanning/1)

To fix this issue, you should add a `permissions` block specifying the least privileges required for this workflow. For most workflows that only need to checkout code and access secrets, `contents: read` is usually sufficient. The `permissions` block should be added at the root level (before the `jobs:` section) to apply to all jobs in the workflow, unless a job has more specific requirements. For the workflow in `.github/workflows/push.yaml`, add these lines immediately after the workflow `name:` declaration but before the `on:` trigger. This ensures that the `GITHUB_TOKEN` has only read access to repository contents and does not unintentionally grant write permissions.

You do not need to modify any imports or add definitions; only a small change to the root YAML structure is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
