### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,6 @@
 name: PR
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/amperka/serial-projector/security/code-scanning/2](https://github.com/amperka/serial-projector/security/code-scanning/2)

To fix this issue, add a `permissions` block specifying the least privilege necessary to the workflow. Since the workflow only checks out code and runs CI commands and does not interact with repo settings, artifacts, or pull requests, the minimal required permission is `contents: read`. The `permissions` block can be placed at the root level so it applies to all jobs (since only one job is present), or inside the `test` job. For future maintainability, root-level placement is generally preferred. This involves editing the `.github/workflows/pr.yaml` file and inserting the following block after the workflow’s `name`, prior to the `on:` block:

```yaml
permissions:
  contents: read
```

No additional dependencies or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
