### PR TITLE
Ability to set port signals

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,7 @@ export default defineConfig([
     },
 
     rules: {
+      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
       semi: "error",
       "prefer-const": "warn",
       "prettier/prettier": "warn",

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   </head>
   <body>
     <main>
-      <div id="message">🔌</div>
+      <div id="msg">🔌</div>
     </main>
 
     <div id="status">Disconnected</div>
@@ -38,7 +38,10 @@
         <h2>Connection Settings</h2>
         <label
           >Baud rate:
-          <select id="baudRate">
+          <select
+            id="baudRate"
+            title="A positive, non-zero value indicating the baud rate at which serial communication should be established."
+          >
             <option>9600</option>
             <option>19200</option>
             <option>38400</option>
@@ -48,14 +51,20 @@
         </label>
         <label
           >Data bits:
-          <select id="dataBits">
+          <select
+            id="dataBits"
+            title="An integer value of 7 or 8 indicating the number of data bits per frame. If not passed, defaults to 8."
+          >
             <option value="7">7</option>
             <option value="8" selected>8</option>
           </select>
         </label>
         <label
           >Parity:
-          <select id="parity">
+          <select
+            id="parity"
+            title='The parity mode, either "none", "even", or "odd". The default value is "none".'
+          >
             <option value="none" selected>None</option>
             <option value="odd">Odd</option>
             <option value="even">Even</option>
@@ -63,14 +72,20 @@
         </label>
         <label
           >Stop bits:
-          <select id="stopBits">
+          <select
+            id="stopBits"
+            title="An integer value of 1 or 2 indicating the number of stop bits at the end of the frame."
+          >
             <option value="1" selected>1</option>
             <option value="2">2</option>
           </select>
         </label>
         <label
           >Encoding:
-          <select id="encoding">
+          <select
+            id="encoding"
+            title="From which encoding to recode if it is not UTF-8."
+          >
             <option value="default" selected>Default (UTF-8)</option>
             <option value="utf-8">UTF-8</option>
             <option value="x-espruino-mixed-utf8">
@@ -115,6 +130,44 @@
             <option value="euc-kr">EUC-KR</option>
           </select>
         </label>
+
+        <h3>Signals</h3>
+        <div class="modal-content-inline">
+          <label
+            ><abbr title="Data Terminal Ready">DTR</abbr>:
+            <select
+              id="dtrSignal"
+              title='A boolean indicating whether to invoke the operating system to either assert (if true) or de-assert (if false) the "data terminal ready" or "DTR" signal on the serial port.'
+            >
+              <option value="" selected>Default</option>
+              <option value="true" selected>Yes</option>
+              <option value="false">No</option>
+            </select>
+          </label>
+          <label
+            ><abbr title="Request to Send">RTS</abbr>:
+            <select
+              id="rtsSignal"
+              title='A boolean indicating whether to invoke the operating system to either assert (if true) or de-assert (if false) the "request to send" or "RTS" signal on the serial port.'
+            >
+              <option value="" selected>Default</option>
+              <option value="true">Yes</option>
+              <option value="false">No</option>
+            </select>
+          </label>
+          <label
+            ><code>break</code>:
+            <select
+              id="breakSignal"
+              title='A boolean indicating whether to invoke the operating system to either assert (if true) or de-assert (if false) the "break" signal on the serial port.'
+            >
+              <option value="" selected>Default</option>
+              <option value="true">Yes</option>
+              <option value="false">No</option>
+            </select>
+          </label>
+        </div>
+
         <button id="connectBtn" title="Connect and turn autoconnection on">
           Connect
         </button>
@@ -124,7 +177,7 @@
         >
           Disconnect
         </button>
-        <button id="closeSettings">Close</button>
+        <button id="settingsClose">Close</button>
       </div>
     </div>
 
@@ -157,7 +210,7 @@
             value="10"
           />
         </label>
-        <button id="closeStyle">Close</button>
+        <button id="styleClose">Close</button>
       </div>
     </div>
 
@@ -177,7 +230,7 @@
           >
           is available on GitHub.
         </p>
-        <button id="closeAbout">Close</button>
+        <button id="aboutClose">Close</button>
       </div>
     </div>
 

--- a/src/state.js
+++ b/src/state.js
@@ -9,6 +9,9 @@
  * @property {string} parity - Parity
  * @property {number} stopBits - Stop bits
  * @property {string} encoding - Text encoding
+ * @property {boolean | null} dtrSignal - Send DTR signal
+ * @property {boolean | null} rtsSignal - Send RTS signal
+ * @property {boolean | null} breakSignal - Send break signal
  * @property {boolean} isFullscreen - Fullscreen mode state
  * @property {boolean} isSettingsModalOpened - Settings modal state
  * @property {boolean} isStyleModalOpened - Style modal state

--- a/src/storage.js
+++ b/src/storage.js
@@ -18,7 +18,7 @@ const PERSIST_STATE_NUM_KEYS = ["fontSize", "baudRate", "dataBits", "stopBits"];
 /** @type {(keyof State)[]} */
 const PERSIST_STATE_OBJ_KEYS = ["lastPortInfo"];
 /** @type {(keyof State)[]} */
-const PERSIST_STATE_BOOL_KEYS = [];
+const PERSIST_STATE_BOOL_KEYS = ["dtrSignal", "rtsSignal", "breakSignal"];
 
 /** @type {(keyof State)[]} */
 const PERSIST_STATE_KEYS = PERSIST_STATE_STR_KEYS.concat(PERSIST_STATE_NUM_KEYS)
@@ -59,7 +59,7 @@ const loadState = () => {
       state[k] = +value;
     }
     if (PERSIST_STATE_BOOL_KEYS.includes(k)) {
-      state[k] = value === "true" ? true : false;
+      state[k] = value === "true" ? true : value === "false" ? false : null;
     }
     if (PERSIST_STATE_OBJ_KEYS.includes(k)) {
       try {

--- a/src/style.css
+++ b/src/style.css
@@ -76,3 +76,11 @@ video {
   display: block;
   margin-bottom: 10px;
 }
+
+.modal-content-inline {
+  display: flex;
+}
+
+.modal-content-inline label {
+  padding: 5px;
+}

--- a/src/ui.js
+++ b/src/ui.js
@@ -24,7 +24,40 @@
  * @property {HTMLElement} parity - Parity HTML element
  * @property {HTMLElement} stopBits - Stop bits HTML element
  * @property {HTMLElement} encoding - Encoding HTML element
+ * @property {HTMLElement} dtrSignal - Encoding HTML element
+ * @property {HTMLElement} rtsSignal - Encoding HTML element
+ * @property {HTMLElement} breakSignal - Encoding HTML element
  */
+/** @type {keyof AppHTMLElements} */
+export const appHtmlElementNames = [
+  "doc",
+  "msg",
+  "status",
+  "settingsBtn",
+  "settingsClose",
+  "settingsModal",
+  "styleBtn",
+  "styleClose",
+  "styleModal",
+  "fullscreenBtn",
+  "aboutBtn",
+  "aboutModal",
+  "aboutClose",
+  "connectBtn",
+  "disconnectBtn",
+  "bgColor",
+  "textColor",
+  "fontFamily",
+  "fontSize",
+  "baudRate",
+  "dataBits",
+  "parity",
+  "stopBits",
+  "encoding",
+  "dtrSignal",
+  "rtsSignal",
+  "breakSignal",
+];
 
 /**
  * @typedef {import('./state.js').State} State
@@ -68,6 +101,24 @@ export const loadStateFromDOM = (el) => ({
   parity: el.parity.value,
   stopBits: +el.stopBits.value,
   encoding: el.encoding.value,
+  dtrSignal:
+    el.dtrSignal.value === "true"
+      ? true
+      : el.dtrSignal.value === "false"
+        ? false
+        : null,
+  rtsSignal:
+    el.rtsSignal.value === "true"
+      ? true
+      : el.rtsSignal.value === "false"
+        ? false
+        : null,
+  breakSignal:
+    el.breakSignal.value == "true"
+      ? true
+      : el.breakSignal.value == "false"
+        ? false
+        : null,
   isFullscreen: Boolean(el.doc.fullscreenElement),
   isSettingsModalOpened: !isModalClosed(el.settingsModal),
   isStyleModalOpened: !isModalClosed(el.styleModal),
@@ -101,6 +152,23 @@ export const renderPortSettings = (el, state, oldState) => {
 
   if (state.encoding !== oldState.encoding) {
     el.encoding.value = state.encoding;
+  }
+
+  if (state.dtrSignal !== oldState.dtrSignal) {
+    el.dtrSignal.value =
+      typeof state.dtrSignal === "boolean" ? state.dtrSignal.toString() : "";
+  }
+
+  if (state.rtsSignal !== oldState.rtsSignal) {
+    el.rtsSignal.value =
+      typeof state.rtsSignal === "boolean" ? state.rtsSignal.toString() : "";
+  }
+
+  if (state.breakSignal !== oldState.breakSignal) {
+    el.breakSignal.value =
+      typeof state.breakSignal === "boolean"
+        ? state.breakSignal.toString()
+        : "";
   }
 };
 
@@ -140,6 +208,36 @@ export const bindPortSettings = (el, store) => {
   );
   el.encoding.addEventListener("change", (e) =>
     store.setState({ encoding: e.target.value }),
+  );
+  el.dtrSignal.addEventListener("change", (e) =>
+    store.setState({
+      dtrSignal:
+        e.target.value === "true"
+          ? true
+          : e.target.value === "false"
+            ? false
+            : null,
+    }),
+  );
+  el.rtsSignal.addEventListener("change", (e) =>
+    store.setState({
+      rtsSignal:
+        e.target.value === "true"
+          ? true
+          : e.target.value === "false"
+            ? false
+            : null,
+    }),
+  );
+  el.breakSignal.addEventListener("change", (e) =>
+    store.setState({
+      breakSignal:
+        e.target.value === "true"
+          ? true
+          : e.target.value === "false"
+            ? false
+            : null,
+    }),
   );
 };
 

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -642,6 +642,7 @@ describe("init", () => {
         getInfo: vi.fn().mockReturnValue({}),
         requestPort: vi.fn(),
         decoder: { encoding: "utf-8", decode: vi.fn() },
+        setSignals: vi.fn(),
       };
       const MockPortClass = vi.fn().mockImplementation(() => mockPort);
 

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -208,6 +208,44 @@ describe("main.js", () => {
     });
   });
 
+  describe("getPortSignalOptsFromState", () => {
+    it("should extract port signal options from state with boolean values", () => {
+      const state = {
+        dtrSignal: true,
+        rtsSignal: false,
+        breakSignal: true,
+      };
+      const signals = mainModule.getPortSignalOptsFromState(state);
+      expect(signals).toEqual({
+        dataTerminalReady: true,
+        requestToSend: false,
+        break: true,
+      });
+    });
+
+    it("should filter out null signal values", () => {
+      const state = {
+        dtrSignal: null,
+        rtsSignal: false,
+        breakSignal: null,
+      };
+      const signals = mainModule.getPortSignalOptsFromState(state);
+      expect(signals).toEqual({
+        requestToSend: false,
+      });
+    });
+
+    it("should return empty object when all signals are null", () => {
+      const state = {
+        dtrSignal: null,
+        rtsSignal: null,
+        breakSignal: null,
+      };
+      const signals = mainModule.getPortSignalOptsFromState(state);
+      expect(signals).toEqual({});
+    });
+  });
+
   describe("getStore", () => {
     it("should create a StateContainer with state loaded from DOM", () => {
       const mockElements = setupTestEnvironment().mockElements;

--- a/tests/port.test.js
+++ b/tests/port.test.js
@@ -73,6 +73,42 @@ describe("Port", () => {
     });
   });
 
+  describe("signals functionality", () => {
+    it("should set signals in constructor", () => {
+      const signals = {
+        dataTerminalReady: true,
+        requestToSend: false,
+      };
+      const port = new Port({}, {}, {}, signals);
+      expect(port).toBeDefined();
+    });
+
+    it("should update signals via setSignals method", () => {
+      const port = new Port({});
+      const newSignals = {
+        dataTerminalReady: true,
+        requestToSend: false,
+        break: true,
+      };
+
+      port.setSignals(newSignals);
+      // The signals are stored privately, but we can verify the method exists and doesn't throw
+      expect(typeof port.setSignals).toBe("function");
+    });
+
+    it("should handle empty signals object", () => {
+      const port = new Port({});
+      port.setSignals({});
+      expect(typeof port.setSignals).toBe("function");
+    });
+
+    it("should handle null signals", () => {
+      const port = new Port({});
+      port.setSignals(null);
+      expect(typeof port.setSignals).toBe("function");
+    });
+  });
+
   describe("decoder functionality", () => {
     it("should set decoder property in constructor", () => {
       const customDecoder = mkDecoder("utf-8");

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -56,6 +56,27 @@ describe("storage.js", () => {
       );
     });
 
+    it("should save boolean keys to localStorage", () => {
+      const state = {
+        dtrSignal: true,
+        rtsSignal: false,
+        breakSignal: null,
+      };
+      saveState(state);
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        "state_dtrSignal",
+        true,
+      );
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        "state_rtsSignal",
+        false,
+      );
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        "state_breakSignal",
+        null,
+      );
+    });
+
     it("should ignore non-persisted keys", () => {
       const state = {
         bgColor: "#ffffff",
@@ -134,6 +155,37 @@ describe("storage.js", () => {
       const result = loadState();
       expect(result).toEqual({
         bgColor: "#ffffff",
+      });
+    });
+
+    it("should handle three-state boolean values from localStorage", () => {
+      localStorage.getItem.mockImplementation((key) => {
+        if (key === "state_dtrSignal") return "true";
+        if (key === "state_rtsSignal") return "false";
+        if (key === "state_breakSignal") return "";
+        return null;
+      });
+      const result = loadState();
+      expect(result).toEqual({
+        dtrSignal: true,
+        rtsSignal: false,
+        breakSignal: null,
+      });
+    });
+
+    it("should parse boolean values with three-state logic", () => {
+      localStorage.getItem.mockImplementation((key) => {
+        if (key === "state_dtrSignal") return "true";
+        if (key === "state_rtsSignal") return "false";
+        if (key === "state_breakSignal") return "invalid";
+        if (key === "state_otherSignal") return null;
+        return null;
+      });
+      const result = loadState();
+      expect(result).toEqual({
+        dtrSignal: true,
+        rtsSignal: false,
+        breakSignal: null,
       });
     });
 

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -80,6 +80,9 @@ describe("ui.js", () => {
         parity: { value: "none" },
         stopBits: { value: "1" },
         encoding: { value: "default" },
+        dtrSignal: { value: "" },
+        rtsSignal: { value: "true" },
+        breakSignal: { value: "false" },
       };
       const state = loadStateFromDOM(mockEl);
       expect(state).toEqual({
@@ -98,6 +101,9 @@ describe("ui.js", () => {
         message: "<p>test message</p>",
         status: "connected",
         encoding: "default",
+        dtrSignal: null,
+        rtsSignal: true,
+        breakSignal: false,
       });
     });
   });
@@ -171,6 +177,9 @@ describe("ui.js", () => {
       parity: createMockInput(),
       stopBits: createMockInput(),
       encoding: createMockInput(),
+      dtrSignal: createMockInput(),
+      rtsSignal: createMockInput(),
+      breakSignal: createMockInput(),
     });
 
     it("binds settingsBtn click to open settings modal", () => {
@@ -763,6 +772,9 @@ describe("ui.js", () => {
         parity: { value: "none" },
         stopBits: { value: "1" },
         encoding: { value: "utf-8" },
+        dtrSignal: { value: "" },
+        rtsSignal: { value: "" },
+        breakSignal: { value: "" },
       };
       const state = {
         bgColor: "#fff",
@@ -780,6 +792,9 @@ describe("ui.js", () => {
         message: "<p>msg</p>",
         status: "connected",
         encoding: "utf-8",
+        dtrSignal: null,
+        rtsSignal: null,
+        breakSignal: null,
       };
       await renderState(el, state);
       // Check some changes
@@ -818,6 +833,9 @@ describe("ui.js", () => {
         parity: createMockInput(),
         stopBits: createMockInput(),
         encoding: createMockInput(),
+        dtrSignal: createMockInput(),
+        rtsSignal: createMockInput(),
+        breakSignal: createMockInput(),
       };
       bindStateToDOM(el, store);
       // Since subscribe is called, and render is subscribed, we can check by setting state and seeing if renderState was called indirectly

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import {
+  appHtmlElementNames,
   isModalClosed,
   openModal,
   closeModal,
@@ -85,7 +86,7 @@ describe("ui.js", () => {
         breakSignal: { value: "false" },
       };
       const state = loadStateFromDOM(mockEl);
-      expect(state).toEqual({
+      const expected = {
         bgColor: "#000000",
         textColor: "#ffffff",
         fontFamily: "Arial",
@@ -104,6 +105,34 @@ describe("ui.js", () => {
         dtrSignal: null,
         rtsSignal: true,
         breakSignal: false,
+      };
+      expect(state).toEqual(expected);
+
+      const mockElSignals1 = {
+        ...mockEl,
+        dtrSignal: { value: "true" },
+        rtsSignal: { value: "false" },
+        breakSignal: { value: "" },
+      };
+      const stateSignals1 = loadStateFromDOM(mockElSignals1);
+      expect(stateSignals1).toEqual({
+        ...expected,
+        dtrSignal: true,
+        rtsSignal: false,
+        breakSignal: null,
+      });
+      const mockElSignals2 = {
+        ...mockEl,
+        dtrSignal: { value: "false" },
+        rtsSignal: { value: "" },
+        breakSignal: { value: "true" },
+      };
+      const stateSignals2 = loadStateFromDOM(mockElSignals2);
+      expect(stateSignals2).toEqual({
+        ...expected,
+        dtrSignal: false,
+        rtsSignal: null,
+        breakSignal: true,
       });
     });
   });
@@ -163,6 +192,76 @@ describe("ui.js", () => {
       const oldState = { encoding: "utf-8" };
       renderPortSettings(el, state, oldState);
       expect(el.encoding.value).toBe("utf-8");
+    });
+
+    it("updates dtrSignal if changed", () => {
+      const el = { dtrSignal: { value: "false" } };
+      const state = { dtrSignal: true };
+      const oldState = { dtrSignal: false };
+      renderPortSettings(el, state, oldState);
+      expect(el.dtrSignal.value).toBe("true");
+    });
+
+    it("does not update dtrSignal if not changed", () => {
+      const el = { dtrSignal: { value: "true" } };
+      const state = { dtrSignal: true };
+      const oldState = { dtrSignal: true };
+      renderPortSettings(el, state, oldState);
+      expect(el.dtrSignal.value).toBe("true");
+    });
+
+    it("updates rtsSignal if changed", () => {
+      const el = { rtsSignal: { value: "true" } };
+      const state = { rtsSignal: false };
+      const oldState = { rtsSignal: true };
+      renderPortSettings(el, state, oldState);
+      expect(el.rtsSignal.value).toBe("false");
+    });
+
+    it("does not update dtrSignal if not changed", () => {
+      const el = { dtrSignal: { value: "true" } };
+      const state = { dtrSignal: true };
+      const oldState = { dtrSignal: true };
+      renderPortSettings(el, state, oldState);
+      expect(el.dtrSignal.value).toBe("true");
+    });
+
+    it("updates breakSignal if changed", () => {
+      const el = { breakSignal: { value: "" } };
+      const state = { breakSignal: true };
+      const oldState = { breakSignal: null };
+      renderPortSettings(el, state, oldState);
+      expect(el.breakSignal.value).toBe("true");
+    });
+
+    it("does not update breakSignal if not changed", () => {
+      const el = { breakSignal: { value: "true" } };
+      const state = { breakSignal: true };
+      const oldState = { breakSignal: true };
+      renderPortSettings(el, state, oldState);
+      expect(el.breakSignal.value).toBe("true");
+    });
+
+    it("sets signal value to empty string when signal is null", () => {
+      const el = {
+        dtrSignal: { value: "true" },
+        rtsSignal: { value: "false" },
+        breakSignal: { value: "true" },
+      };
+      const state = {
+        dtrSignal: null,
+        rtsSignal: null,
+        breakSignal: null,
+      };
+      const oldState = {
+        dtrSignal: true,
+        rtsSignal: false,
+        breakSignal: true,
+      };
+      renderPortSettings(el, state, oldState);
+      expect(el.dtrSignal.value).toBe("");
+      expect(el.rtsSignal.value).toBe("");
+      expect(el.breakSignal.value).toBe("");
     });
   });
 
@@ -267,6 +366,60 @@ describe("ui.js", () => {
       el.encoding.value = "ascii";
       el.encoding.dispatchEvent(new Event("change"));
       expect(store.setState).toHaveBeenCalledWith({ encoding: "ascii" });
+    });
+
+    it("binds dtrSignal change to update state", () => {
+      const store = { setState: vi.fn() };
+      const el = createPortSettingsElements();
+      bindPortSettings(el, store);
+
+      el.dtrSignal.value = "true";
+      el.dtrSignal.dispatchEvent(new Event("change"));
+      expect(store.setState).toHaveBeenCalledWith({ dtrSignal: true });
+
+      el.dtrSignal.value = "false";
+      el.dtrSignal.dispatchEvent(new Event("change"));
+      expect(store.setState).toHaveBeenCalledWith({ dtrSignal: false });
+
+      el.dtrSignal.value = "";
+      el.dtrSignal.dispatchEvent(new Event("change"));
+      expect(store.setState).toHaveBeenCalledWith({ dtrSignal: null });
+    });
+
+    it("binds rtsSignal change to update state", () => {
+      const store = { setState: vi.fn() };
+      const el = createPortSettingsElements();
+      bindPortSettings(el, store);
+
+      el.rtsSignal.value = "true";
+      el.rtsSignal.dispatchEvent(new Event("change"));
+      expect(store.setState).toHaveBeenCalledWith({ rtsSignal: true });
+
+      el.rtsSignal.value = "false";
+      el.rtsSignal.dispatchEvent(new Event("change"));
+      expect(store.setState).toHaveBeenCalledWith({ rtsSignal: false });
+
+      el.rtsSignal.value = "";
+      el.rtsSignal.dispatchEvent(new Event("change"));
+      expect(store.setState).toHaveBeenCalledWith({ rtsSignal: null });
+    });
+
+    it("binds breakSignal change to update state", () => {
+      const store = { setState: vi.fn() };
+      const el = createPortSettingsElements();
+      bindPortSettings(el, store);
+
+      el.breakSignal.value = "true";
+      el.breakSignal.dispatchEvent(new Event("change"));
+      expect(store.setState).toHaveBeenCalledWith({ breakSignal: true });
+
+      el.breakSignal.value = "false";
+      el.breakSignal.dispatchEvent(new Event("change"));
+      expect(store.setState).toHaveBeenCalledWith({ breakSignal: false });
+
+      el.breakSignal.value = "";
+      el.breakSignal.dispatchEvent(new Event("change"));
+      expect(store.setState).toHaveBeenCalledWith({ breakSignal: null });
     });
   });
 
@@ -802,6 +955,39 @@ describe("ui.js", () => {
       expect(el.bgColor.value).toBe("#fff");
       expect(el.baudRate.value).toBe(115200);
       expect(el.msg.innerHTML).toBe("<p>msg</p>");
+    });
+
+    describe("appHtmlElementNames", () => {
+      it("should export array of HTML element names", () => {
+        expect(Array.isArray(appHtmlElementNames)).toBe(true);
+        expect(appHtmlElementNames).toContain("doc");
+        expect(appHtmlElementNames).toContain("msg");
+        expect(appHtmlElementNames).toContain("status");
+        expect(appHtmlElementNames).toContain("settingsBtn");
+        expect(appHtmlElementNames).toContain("settingsClose");
+        expect(appHtmlElementNames).toContain("settingsModal");
+        expect(appHtmlElementNames).toContain("styleBtn");
+        expect(appHtmlElementNames).toContain("styleClose");
+        expect(appHtmlElementNames).toContain("styleModal");
+        expect(appHtmlElementNames).toContain("fullscreenBtn");
+        expect(appHtmlElementNames).toContain("aboutBtn");
+        expect(appHtmlElementNames).toContain("aboutModal");
+        expect(appHtmlElementNames).toContain("aboutClose");
+        expect(appHtmlElementNames).toContain("connectBtn");
+        expect(appHtmlElementNames).toContain("disconnectBtn");
+        expect(appHtmlElementNames).toContain("bgColor");
+        expect(appHtmlElementNames).toContain("textColor");
+        expect(appHtmlElementNames).toContain("fontFamily");
+        expect(appHtmlElementNames).toContain("fontSize");
+        expect(appHtmlElementNames).toContain("baudRate");
+        expect(appHtmlElementNames).toContain("dataBits");
+        expect(appHtmlElementNames).toContain("parity");
+        expect(appHtmlElementNames).toContain("stopBits");
+        expect(appHtmlElementNames).toContain("encoding");
+        expect(appHtmlElementNames).toContain("dtrSignal");
+        expect(appHtmlElementNames).toContain("rtsSignal");
+        expect(appHtmlElementNames).toContain("breakSignal");
+      });
     });
   });
 


### PR DESCRIPTION
Ability to set port signals. Supported signals: DTR, RTS, break. Same as Web Serial's `setSignals()`.

<img width="467" height="533" alt="image" src="https://github.com/user-attachments/assets/5121434f-764d-48d8-9129-8f7a6fd7ee99" />

It is related to https://github.com/amperka/serial-projector/issues/39. Most likely, this cannot be fixed because the signals can only be set to an open port according to the specification. Thus, the initial values cannot be set.